### PR TITLE
Allow html tags in comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,9 +84,20 @@ module.exports = function(js, callback){
         
         var comments = section.comments.join(i===0?'\n\n':'\n');
         try{
-            var md = escapeHtml(comments)
+            var md = comments
                        .replace(/^( *[@])/mg, '\n$1');
-            section.comments = markdown(md).replace(/[\n]+/gm,' ');
+            section.comments = markdown(
+                                  md,
+                                  false,
+                                  'a|b|blockquote|code|del|dd|dl|dt|em|h1|h2|h3|i|img|li|ol|p|pre|sup|sub|strong|strike|ul|br|hr|img',
+                                  {
+                                    iframe: 'src|width|height|allowfullscreen|frameborder',
+                                    img: 'src|width|height|alt',
+                                    a:'href',
+                                    '*': 'title'
+                                  },
+                                  true
+                                ).replace(/[\n]+/gm,' ');
         }catch(ex){ 
             section.comments = comments;
         }

--- a/node_modules/node-markdown/lib/markdown.js
+++ b/node_modules/node-markdown/lib/markdown.js
@@ -35,7 +35,7 @@ this.Markdown = function(text, stripUnwanted, allowedTags, allowedAttributes, fo
  * 
  * Removes unwanted tags and attributes from HTML string
  **/
-var stripUnwantedHTML = function(html /*, allowedTags, allowedAttributes, forceProtocol */){
+var stripUnwantedHTML = function(html, allowedTags, allowedAttributes, forceProtocol){
     var allowedTags = arguments[1] || 
             'a|b|blockquote|code|del|dd|dl|dt|em|h1|h2|h3|'+
             'i|img|li|ol|p|pre|sup|sub|strong|strike|ul|br|hr',


### PR DESCRIPTION
In the explainjs code the html tags in doc comments are escaped.
If you want to create a rich documentation you can use the markdown options to allow or not the tags you need.
If I need to include some examples of code in jsfiddle or something similar I want to see it work in my documentation results.
